### PR TITLE
Add webdrv App File

### DIFF
--- a/ebin/webdrv.app
+++ b/ebin/webdrv.app
@@ -1,0 +1,6 @@
+{application, webdrv, [
+  {description, "WebDriver implementation in Erlang"},
+  {modules, [json, webdrv_cap, webdrv_session, webdrv_wire]},
+  {applications, [kernel, stdlib]},
+  {vsn, "1.0.0"}
+]}.


### PR DESCRIPTION
Adding the .app file to the ebin directory makes it so this app can be compiled by rebar3 and makes webdrv an OTP library.
